### PR TITLE
Clarify remote dependencies and auto-apply "parsable" directive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+### Added
+- Added instructions to the `README` for the remote machine's dependencies.
+
+### Changed
+- Automatically apply the `"parsable": ""` option by default if not set by the user.
+
 ## [0.10.0] - 2023-05-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ To use this plugin with Covalent, simply install it using `pip`:
 pip install covalent-slurm-plugin
 ```
 
-On the remote system, the Python environment you plan to use must be the same as the one you use to dispatch the calculations. Additionally, the remote system's Python environment must have the base [covalent package](https://github.com/AgnostiqHQ/covalent) installed (e.g. `pip install covalent`) in addition to [cloudpickle](https://github.com/cloudpipe/cloudpickle), which will automatically be installed with the former.
+On the remote system, the Python version in the environment you plan to use must match that used when dispatching the calculations. Additionally, the remote system's Python environment must have the base [covalent package](https://github.com/AgnostiqHQ/covalent) installed (e.g. `pip install covalent`) in addition to [cloudpickle](https://github.com/cloudpipe/cloudpickle), the latter of which will automatically be installed with covalent.
 
 ## Usage
 The following shows an example of a Covalent [configuration](https://covalent.readthedocs.io/en/latest/how_to/config/customization.html) that is modified to support Slurm:

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ To use this plugin with Covalent, simply install it using `pip`:
 pip install covalent-slurm-plugin
 ```
 
-On the remote system, the Python version in the environment you plan to use must match that used when dispatching the calculations. Additionally, the remote system's Python environment must have the base [covalent package](https://github.com/AgnostiqHQ/covalent) installed (e.g. `pip install covalent`) in addition to [cloudpickle](https://github.com/cloudpipe/cloudpickle), the latter of which will automatically be installed with covalent.
+On the remote system, the Python version in the environment you plan to use must match that used when dispatching the calculations. Additionally, the remote system's Python environment must have the base [covalent package](https://github.com/AgnostiqHQ/covalent) installed (e.g. `pip install covalent`).
 
 ## Usage
 The following shows an example of a Covalent [configuration](https://covalent.readthedocs.io/en/latest/how_to/config/customization.html) that is modified to support Slurm:

--- a/README.md
+++ b/README.md
@@ -16,12 +16,16 @@
 
 Covalent is a Pythonic workflow tool used to execute tasks on advanced computing hardware. This executor plugin interfaces Covalent with HPC systems managed by [Slurm](https://slurm.schedmd.com/documentation.html). For workflows to be deployable, users must have SSH access to the Slurm login node, writable storage space on the remote filesystem, and permissions to submit jobs to Slurm.
 
+## Installation
 To use this plugin with Covalent, simply install it using `pip`:
 
 ```
 pip install covalent-slurm-plugin
 ```
 
+On the remote system, the Python environment you plan to use must be the same as the one you use to dispatch the calculations. Additionally, the remote system's Python environment must have the base [covalent package](https://github.com/AgnostiqHQ/covalent) installed (e.g. `pip install covalent`) in addition to [cloudpickle](https://github.com/cloudpipe/cloudpickle), which will automatically be installed with the former.
+
+## Usage
 The following shows an example of a Covalent [configuration](https://covalent.readthedocs.io/en/latest/how_to/config/customization.html) that is modified to support Slurm:
 
 ```console

--- a/covalent_slurm_plugin/slurm.py
+++ b/covalent_slurm_plugin/slurm.py
@@ -135,7 +135,7 @@ class SlurmExecutor(AsyncBaseExecutor):
         self.poll_freq = poll_freq
         self.cleanup = cleanup
 
-        # Ensure that the slurm data is pasable
+        # Ensure that the slurm data is parsable
         if "parsable" not in self.options:
             self.options["parsable"] = ""
 

--- a/covalent_slurm_plugin/slurm.py
+++ b/covalent_slurm_plugin/slurm.py
@@ -135,6 +135,10 @@ class SlurmExecutor(AsyncBaseExecutor):
         self.poll_freq = poll_freq
         self.cleanup = cleanup
 
+        # Ensure that the slurm data is pasable
+        if "parsable" not in self.options:
+            self.options["parsable"] = ""
+
         self.LOAD_SLURM_PREFIX = "source /etc/profile\n module whatis slurm &> /dev/null\n if [ $? -eq 0 ] ; then\n module load slurm\n fi\n"
 
     async def _client_connect(self) -> asyncssh.SSHClientConnection:

--- a/tests/slurm_test.py
+++ b/tests/slurm_test.py
@@ -122,7 +122,7 @@ def test_init():
     assert executor.conda_env == conda_env
     assert executor.poll_freq == poll_freq
     assert executor.cache_dir == cache_dir
-    assert executor.options == {}
+    assert executor.options == {"parsable": ""}
 
 
 def test_format_py_script():


### PR DESCRIPTION
This PR closes #48 and does two things:

1. Adds installation instructions related to dependencies on the remote machine.
2. Auto-applies the `parsable` option if not set since this is required by covalent to read the queue status and other slurm information.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation, VERSION, and CHANGELOG accordingly.
- [x] I have read the CONTRIBUTING document.

Once approved, I will make the same change in the covalent docs for the SLURM executor.