### PR TITLE
Fix logic in `self.cleanup`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+### Fixed
+
+- Fixed a bug where `cleanup = False` would be ignored.
+
 ## [0.12.1] - 2023-05-05
 
 ### Fixed

--- a/covalent_slurm_plugin/slurm.py
+++ b/covalent_slurm_plugin/slurm.py
@@ -163,7 +163,10 @@ class SlurmExecutor(AsyncBaseExecutor):
             print("Polling frequency will be increased to the minimum for Slurm: 60 seconds.")
             self.poll_freq = 60
 
-        self.cleanup = cleanup or get_config("executors.slurm.cleanup")
+        if cleanup is None:
+            self.cleanup = get_config("executors.slurm.cleanup")
+        else:
+            self.cleanup = cleanup
 
         # Ensure that the slurm data is parsable
         if "parsable" not in self.options:

--- a/tests/slurm_test.py
+++ b/tests/slurm_test.py
@@ -99,6 +99,7 @@ def test_init():
     conda_env = "test_env"
     poll_freq = 90
     cache_dir = "/test/cache/dir"
+    cleanup = False
 
     executor = SlurmExecutor(
         username=username,
@@ -110,6 +111,7 @@ def test_init():
         conda_env=conda_env,
         poll_freq=poll_freq,
         cache_dir=cache_dir,
+        cleanup=cleanup,
         options={},
     )
 
@@ -122,6 +124,7 @@ def test_init():
     assert executor.conda_env == conda_env
     assert executor.poll_freq == poll_freq
     assert executor.cache_dir == cache_dir
+    assert executor.cleanup == cleanup
     assert executor.options == {"parsable": ""}
 
 

--- a/tests/slurm_test.py
+++ b/tests/slurm_test.py
@@ -87,6 +87,7 @@ def test_init():
     assert executor.cache_dir == str(
         Path(get_config("dispatcher.cache_dir")).expanduser().resolve()
     )
+    assert executor.cleanup == True
     assert executor.options == {"parsable": ""}
 
     # Test with non-defaults

--- a/tests/slurm_test.py
+++ b/tests/slurm_test.py
@@ -87,7 +87,7 @@ def test_init():
     assert executor.cache_dir == str(
         Path(get_config("dispatcher.cache_dir")).expanduser().resolve()
     )
-    assert executor.cleanup == True
+    assert executor.cleanup is True
     assert executor.options == {"parsable": ""}
 
     # Test with non-defaults


### PR DESCRIPTION
https://github.com/AgnostiqHQ/covalent-slurm-plugin/blob/bcf2049b61da4e9ddc1d507ef9b56562569d9d84/covalent_slurm_plugin/slurm.py#L166

In the above line, if `cleanup = False` is set by the user, the code will ignore it and still pull from the config and set `cleanup = True`. I fixed the logic.