### PR TITLE
Fix indenting in temp SLURM script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+### Fixed
+
+- Fixed indenting in SLURM submit script.
+
 ## [0.16.0] - 2023-05-12
 
 ### Added

--- a/covalent_slurm_plugin/slurm.py
+++ b/covalent_slurm_plugin/slurm.py
@@ -371,14 +371,14 @@ class SlurmExecutor(AsyncBaseExecutor):
         # sets up conda environment
         if self.conda_env:
             slurm_conda = f"""
-            conda activate {conda_env_clean}
-            retval=$?
-            if [ $retval -ne 0 ] ; then
-                >&2 echo "Conda environment {self.conda_env} is not present on the compute node. "\
-                "Please create the environment and try again."
-                exit 99
-            fi
-            """
+conda activate {conda_env_clean}
+retval=$?
+if [ $retval -ne 0 ] ; then
+    >&2 echo "Conda environment {self.conda_env} is not present on the compute node. "\
+    "Please create the environment and try again."
+    exit 99
+fi
+"""
         else:
             slurm_conda = ""
 


### PR DESCRIPTION
Indenting is fixed in the SLURM submit script.

- [ ] I have added the tests to cover my changes.
- [x] I have updated the documentation, VERSION, and CHANGELOG accordingly.
- [x] I have read the CONTRIBUTING document.
