### PR TITLE
Clarify `ssh_key_file` docstring and modify README for `ct.executor.SlurmExecutor` example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Docs
 
 - Add missing `,` to README.
+- Added `username`, `address`, and `ssh_key_file` to README `ct.executor.SlurmExecutor` example.
 
 ## [0.16.0] - 2023-05-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Docs
 
-- Add missing `,` to README.
+- Clarified docstring for `ssh_key_file`.
 - Added `username`, `address`, and `ssh_key_file` to README `ct.executor.SlurmExecutor` example.
+- Add missing `,` to README.
 
 ## [0.16.0] - 2023-05-12
 

--- a/covalent_slurm_plugin/slurm.py
+++ b/covalent_slurm_plugin/slurm.py
@@ -74,8 +74,8 @@ class SlurmExecutor(AsyncBaseExecutor):
     Args:
         username: Username used to authenticate over SSH.
         address: Remote address or hostname of the Slurm login node.
-        ssh_key_file: Private RSA key used to authenticate over SSH (usually at ~/.ssh/id_rsa).
-        cert_file: Certificate file used to authenticate over SSH, if required (usually has extension .pub).
+        ssh_key_file: Full path to the private RSA key used to authenticate over SSH (usually at /home/username/.ssh/id_rsa).
+        cert_file: Full path to the certificate file used to authenticate over SSH, if required (usually has extension .pub).
         sshproxy: Dictionary of parameters for sshproxy, namely the "hosts": List[str], "username": str, and "secret": str.
         remote_workdir: Working directory on the remote cluster.
         create_unique_workdir: Whether to create a unique working (sub)directory for each task.

--- a/covalent_slurm_plugin/slurm.py
+++ b/covalent_slurm_plugin/slurm.py
@@ -74,8 +74,8 @@ class SlurmExecutor(AsyncBaseExecutor):
     Args:
         username: Username used to authenticate over SSH.
         address: Remote address or hostname of the Slurm login node.
-        ssh_key_file: Full path to the private RSA key used to authenticate over SSH (usually at /home/username/.ssh/id_rsa).
-        cert_file: Full path to the certificate file used to authenticate over SSH, if required (usually has extension .pub).
+        ssh_key_file: Path to the private RSA key used to authenticate over SSH (usually at ~/.ssh/id_rsa). Note that you should use the full, resolved path (i.e. do not use `~/` in the string).
+        cert_file: Path to the certificate file used to authenticate over SSH, if required (usually has extension .pub). Note that you should use the full, resolved path (i.e. do not use `~/` in the string).
         sshproxy: Dictionary of parameters for sshproxy, namely the "hosts": List[str], "username": str, and "secret": str.
         remote_workdir: Working directory on the remote cluster.
         create_unique_workdir: Whether to create a unique working (sub)directory for each task.


### PR DESCRIPTION
This PR seeks to do two things:

1. Clarify the `ssh_key_file` (and `cert_file`) kwargs. Currently, I'm willing to bet many users are going to do `ssh_key_file=~/.ssh/id_rsa"`, but the plugin doesn't call `.expanduser()` on this, and the GUI will show it as "not found" even if it exists.

2. Since the `ct.executor.SlurmExecutor` object requires `username`, `address`, and `ssh_key_file`, I figured it'd be good to add it to the README in a more direct way.