### PR TITLE
Expand `"~/"` in local settings and make `"~/.ssh/id_rsa"` the default for `ssh_key_file`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Changed
 
+- Made "~/.ssh/id_rsa" the default for the `ssh_key_file` kwarg.
+- Automatically expand "~/" in `ssh_key_file`, `cache_dir`, and `cert_file`.
 - Updates __init__ signature kwargs replaced with parent for better documentation.
 
 ### Docs

--- a/covalent_slurm_plugin/slurm.py
+++ b/covalent_slurm_plugin/slurm.py
@@ -44,7 +44,7 @@ log_stack_info = logger.log_stack_info
 _EXECUTOR_PLUGIN_DEFAULTS = {
     "username": "",
     "address": "",
-    "ssh_key_file": "",
+    "ssh_key_file": str(Path("~/.ssh/id_rsa").expanduser().resolve()),
     "sshproxy": {},
     "cert_file": None,
     "remote_workdir": "covalent-workdir",
@@ -130,10 +130,14 @@ class SlurmExecutor(AsyncBaseExecutor):
         self.username = username or get_config("executors.slurm.username")
         self.address = address or get_config("executors.slurm.address")
 
-        self.ssh_key_file = ssh_key_file or get_config("executors.slurm.ssh_key_file")
+        self.ssh_key_file = str(
+            Path(ssh_key_file or get_config("executors.slurm.ssh_key_file")).expanduser().resolve()
+        )
 
         try:
-            self.cert_file = cert_file or get_config("executors.slurm.cert_file")
+            self.cert_file = str(
+                Path(cert_file or get_config("executors.slurm.cert_file")).expanduser().resolve()
+            )
         except KeyError:
             self.cert_file = None
 
@@ -164,7 +168,9 @@ class SlurmExecutor(AsyncBaseExecutor):
         except KeyError:
             self.bashrc_path = None
 
-        self.cache_dir = cache_dir or get_config("executors.slurm.cache_dir")
+        self.cache_dir = str(
+            Path(cache_dir or get_config("executors.slurm.cache_dir")).expanduser().resolve()
+        )
         if not os.path.exists(self.cache_dir):
             os.makedirs(self.cache_dir)
 
@@ -223,9 +229,6 @@ class SlurmExecutor(AsyncBaseExecutor):
 
         if not self.address:
             raise ValueError("address is a required parameter in the Slurm plugin.")
-
-        if not self.ssh_key_file:
-            raise ValueError("ssh_key_file is a required parameter in the Slurm plugin.")
 
         if self.sshproxy and self.address in self.sshproxy["hosts"]:
             try:

--- a/tests/slurm_test.py
+++ b/tests/slurm_test.py
@@ -74,12 +74,11 @@ def test_init():
     # Test with defaults
     username = "username"
     host = "host"
-    key_file = SSH_KEY_FILE
-    executor = SlurmExecutor(username=username, address=host, ssh_key_file=key_file)
+    executor = SlurmExecutor(username=username, address=host)
 
     assert executor.username == username
     assert executor.address == host
-    assert executor.ssh_key_file == SSH_KEY_FILE
+    assert executor.ssh_key_file == str(Path("~/.ssh/id_rsa").expanduser().resolve())
     assert executor.cert_file is None
     assert executor.remote_workdir == "covalent-workdir"
     assert executor.create_unique_workdir is False
@@ -152,7 +151,7 @@ def test_init():
     assert executor.srun_append == srun_append
     assert executor.prerun_commands == prerun_commands
     assert executor.postrun_commands == postrun_commands
-    assert executor.cache_dir == cache_dir
+    assert executor.cache_dir == str(Path(cache_dir).expanduser().resolve())
     assert executor.poll_freq == poll_freq
     assert executor.cleanup == cleanup
 
@@ -394,13 +393,7 @@ async def test_failed_submit_script(mocker, conn_mock):
 
     with pytest.raises(FileNotFoundError):
         executor = SlurmExecutor(
-            username="test_user",
-            address="test_address",
-            ssh_key_file="/this/file/does/not/exist",
-            remote_workdir="/federation/test_user/.cache/covalent",
-            options={},
-            cache_dir="~/.cache/covalent",
-            poll_freq=60,
+            username="test_user", address="test_address", ssh_key_file="/this/file/does/not/exist"
         )
         await executor._client_connect()
 
@@ -410,10 +403,6 @@ async def test_failed_submit_script(mocker, conn_mock):
             address="test_address",
             ssh_key_file=SSH_KEY_FILE,
             cert_file="/this/file/does/not/exist",
-            remote_workdir="/federation/test_user/.cache/covalent",
-            options={},
-            cache_dir="~/.cache/covalent",
-            poll_freq=60,
         )
         await executor._client_connect()
 
@@ -423,10 +412,6 @@ async def test_failed_submit_script(mocker, conn_mock):
 
     with pytest.raises(ValueError):
         executor = SlurmExecutor(username="test", ssh_key_file=SSH_KEY_FILE)
-        await executor._client_connect()
-
-    with pytest.raises(ValueError):
-        executor = SlurmExecutor(username="test", address="test_address")
         await executor._client_connect()
 
 
@@ -576,9 +561,7 @@ async def test_query_result(mocker, proc_mock, conn_mock):
 async def test_run(mocker, proc_mock, conn_mock):
     """Test calling run works as expected."""
     executor1 = SlurmExecutor(
-        username="test_user",
-        address="test_address",
-        ssh_key_file="~/.ssh/id_rsa",
+        username="test_user", address="test_address", ssh_key_file=SSH_KEY_FILE
     )
 
     executor2 = SlurmExecutor(


### PR DESCRIPTION
- [x] I have added the tests to cover my changes.
- [X] I have updated the documentation, VERSION, and CHANGELOG accordingly.
- [X] I have read the CONTRIBUTING document.

I have expanded any user-provided `"~/"` strings in the local settings, such as `ssh_key_file`, `cache_dir`, and `cert_file`. This will hopefully reduce user confusion because otherwise they'll see something like `"~/.ssh/id_rsa"` not found in the GUI.

![image](https://github.com/AgnostiqHQ/covalent-slurm-plugin/assets/8674072/001945ba-dde2-41dc-9383-50056d5f8fcc)

I also made the default value for `ssh_key_file` to be `"~/.ssh/id_rsa"` since that's pretty common.