### PR TITLE
Make `ssh_key_file` optional in `asyncssh.connect` since, by default, `asyncssh` tries many common options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Changed
 
-- Make `ssh_key_file` optional.
-- Updates __init__ signature kwargs replaced with parent for better documentation.
+- Make `ssh_key_file` optional and change executor default to `None`.
+- Updates **init** signature kwargs replaced with parent for better documentation.
 
 ### Docs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Changed
 
+- Make `ssh_key_file` optional.
 - Updates __init__ signature kwargs replaced with parent for better documentation.
 
 ### Docs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Changed
 
-- Make `ssh_key_file` optional and change executor default to `None`.
+- Make `ssh_key_file` optional.
 - Updates **init** signature kwargs replaced with parent for better documentation.
 
 ### Docs

--- a/covalent_slurm_plugin/slurm.py
+++ b/covalent_slurm_plugin/slurm.py
@@ -44,7 +44,7 @@ log_stack_info = logger.log_stack_info
 _EXECUTOR_PLUGIN_DEFAULTS = {
     "username": "",
     "address": "",
-    "ssh_key_file": "",
+    "ssh_key_file": None,
     "sshproxy": {},
     "cert_file": None,
     "remote_workdir": "covalent-workdir",

--- a/covalent_slurm_plugin/slurm.py
+++ b/covalent_slurm_plugin/slurm.py
@@ -44,7 +44,7 @@ log_stack_info = logger.log_stack_info
 _EXECUTOR_PLUGIN_DEFAULTS = {
     "username": "",
     "address": "",
-    "ssh_key_file": None,
+    "ssh_key_file": "",
     "sshproxy": {},
     "cert_file": None,
     "remote_workdir": "covalent-workdir",

--- a/tests/slurm_test.py
+++ b/tests/slurm_test.py
@@ -74,12 +74,11 @@ def test_init():
     # Test with defaults
     username = "username"
     host = "host"
-    key_file = SSH_KEY_FILE
-    executor = SlurmExecutor(username=username, address=host, ssh_key_file=key_file)
+    executor = SlurmExecutor(username=username, address=host)
 
     assert executor.username == username
     assert executor.address == host
-    assert executor.ssh_key_file == SSH_KEY_FILE
+    assert executor.ssh_key_file is None
     assert executor.cert_file is None
     assert executor.remote_workdir == "covalent-workdir"
     assert executor.create_unique_workdir is False

--- a/tests/slurm_test.py
+++ b/tests/slurm_test.py
@@ -78,7 +78,7 @@ def test_init():
 
     assert executor.username == username
     assert executor.address == host
-    assert executor.ssh_key_file is None
+    assert executor.ssh_key_file == ""
     assert executor.cert_file is None
     assert executor.remote_workdir == "covalent-workdir"
     assert executor.create_unique_workdir is False

--- a/tests/slurm_test.py
+++ b/tests/slurm_test.py
@@ -425,10 +425,6 @@ async def test_failed_submit_script(mocker, conn_mock):
         executor = SlurmExecutor(username="test", ssh_key_file=SSH_KEY_FILE)
         await executor._client_connect()
 
-    with pytest.raises(ValueError):
-        executor = SlurmExecutor(username="test", address="test_address")
-        await executor._client_connect()
-
 
 @pytest.mark.asyncio
 async def test_get_status(proc_mock, conn_mock):


### PR DESCRIPTION
- [ ] I have added the tests to cover my changes.
- [X] I have updated the documentation, VERSION, and CHANGELOG accordingly.
- [X] I have read the CONTRIBUTING document.

The `asyncssh.connect` documentation states the following:
```
If no client keys are specified,
an attempt will be made to load them from the files
:file:`.ssh/id_ed25519_sk`, :file:`.ssh/id_ecdsa_sk`,
:file:`.ssh/id_ed448`, :file:`.ssh/id_ed25519`,
:file:`.ssh/id_ecdsa`, :file:`.ssh/id_rsa`, and
:file:`.ssh/id_dsa` in the user's home directory, with
optional certificates loaded from the files
:file:`.ssh/id_ed25519_sk-cert.pub`,
:file:`.ssh/id_ecdsa_sk-cert.pub`, :file:`.ssh/id_ed448-cert.pub`,
:file:`.ssh/id_ed25519-cert.pub`, :file:`.ssh/id_ecdsa-cert.pub`,
:file:`.ssh/id_rsa-cert.pub`, and :file:`.ssh/id_dsa-cert.pub`.
```

As such, I think it would be nice to allow the user to take advantage of this flexibility and not provide an `ssh_key_file` if they want one of these defaults to be selected.

The lines impacted by this PR weren't tested. I'll need to come up with some creative monkeypatching in order to make codecov happy, I think.