### PR TITLE
Set `COVALENT_CONFIG_DIR` to `/tmp` to allow filelock on slurm clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED]
 
+## Added
+
+- export `COVALENT_CONFIG_DIR=/tmp` inside sbatch script to enable filelock
+
 ## Changed
 
+- Aesthetics and string formatting
 - Removed the `sshproxy` interface.
 - Updates __init__ signature kwargs replaced with parent for better documentation.
 - Updated license to Apache

--- a/covalent_slurm_plugin/slurm.py
+++ b/covalent_slurm_plugin/slurm.py
@@ -315,9 +315,9 @@ class SlurmExecutor(AsyncBaseExecutor):
         slurm_env_vars = {
             "COVALENT_CONFIG_DIR": "/tmp",
         }
-        slurm_env_vars = "\n".join(
-            [f"export {key}={value}" for key, value in slurm_env_vars.items()]
-        ) + "\n\n"
+        slurm_env_vars = (
+            "\n".join([f"export {key}={value}" for key, value in slurm_env_vars.items()]) + "\n\n"
+        )
 
         # sets up conda environment
         if self.conda_env:
@@ -384,14 +384,16 @@ fi
         slurm_body = "\n".join([slurm_prerun_commands, python_cmd, slurm_postrun_commands, "wait"])
 
         # assemble script
-        return "".join([
-            slurm_preamble,
-            source_text,
-            slurm_env_vars,
-            slurm_conda,
-            slurm_python_version,
-            slurm_body
-        ])
+        return "".join(
+            [
+                slurm_preamble,
+                source_text,
+                slurm_env_vars,
+                slurm_conda,
+                slurm_python_version,
+                slurm_body,
+            ]
+        )
 
     def _format_py_script(
         self,

--- a/covalent_slurm_plugin/slurm.py
+++ b/covalent_slurm_plugin/slurm.py
@@ -312,17 +312,24 @@ class SlurmExecutor(AsyncBaseExecutor):
         else:
             source_text = ""
 
+        slurm_env_vars = {
+            "COVALENT_CONFIG_DIR": "/tmp",
+        }
+        slurm_env_vars = "\n".join(
+            [f"export {key}={value}" for key, value in slurm_env_vars.items()]
+        ) + "\n\n"
+
         # sets up conda environment
         if self.conda_env:
-            slurm_conda = f"""
-            conda activate {conda_env_clean}
-            retval=$?
-            if [ $retval -ne 0 ] ; then
-                >&2 echo "Conda environment {self.conda_env} is not present on the compute node. "\
-                "Please create the environment and try again."
-                exit 99
-            fi
-            """
+            slurm_conda = f"""\
+conda activate {conda_env_clean}
+retval=$?
+if [ $retval -ne 0 ] ; then
+    >&2 echo "Conda environment {self.conda_env} is not present on the compute node. "\
+    "Please create the environment and try again."
+    exit 99
+fi
+"""
         else:
             slurm_conda = ""
 
@@ -377,9 +384,14 @@ fi
         slurm_body = "\n".join([slurm_prerun_commands, python_cmd, slurm_postrun_commands, "wait"])
 
         # assemble script
-        return "".join(
-            [slurm_preamble, source_text, slurm_conda, slurm_python_version, slurm_body]
-        )
+        return "".join([
+            slurm_preamble,
+            source_text,
+            slurm_env_vars,
+            slurm_conda,
+            slurm_python_version,
+            slurm_body
+        ])
 
     def _format_py_script(
         self,


### PR DESCRIPTION
Fixes: https://github.com/AgnostiqHQ/covalent-slurm-plugin/issues/84

## Added

- export `COVALENT_CONFIG_DIR=/tmp` inside sbatch script to enable filelock

## Changed

- Aesthetics and string formatting

---

- [ ] I have added the tests to cover my changes.
- [x] I have updated the documentation, VERSION, and CHANGELOG accordingly.
- [x] I have read the CONTRIBUTING document.
