### PR TITLE
Clean up and improve error handling

### DIFF
--- a/covalent_slurm_plugin/exec.py
+++ b/covalent_slurm_plugin/exec.py
@@ -1,0 +1,111 @@
+# Copyright 2021 Agnostiq Inc.
+#
+# This file is part of Covalent.
+#
+# Licensed under the Apache License 2.0 (the "License"). A copy of the
+# License may be obtained with this software package or at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Use of this file is prohibited except in compliance with the License.
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""This script executes the electron function on the Slurm cluster."""
+
+import os
+import sys
+
+import cloudpickle as pickle
+
+
+def _check_setup() -> None:
+    """Use these checks to create more informative error messages."""
+
+    import filelock
+
+    msg = ""
+    exception = None
+
+    try:
+        # covalent is needed because the @electron function
+        # executes inside `wrapper_fn` to apply deps
+        import covalent
+
+    except ImportError as _exception:
+
+        msg = "The covalent SDK is not installed in the Slurm job environment."
+        exception = _exception
+
+    except filelock._error.Timeout as _exception:
+
+        config_location = os.getenv("COVALENT_CONFIG_DIR", "~/.config/covalent")
+        config_location = os.path.expanduser(config_location)
+        config_file = os.path.join(config_location, "covalent.conf")
+
+        msg = "\n".join([
+            f"Failed to acquire file lock '{config_file}.lock' on Slurm cluster filesystem. "
+            f"Consider overriding the current config location ('{config_location}'), e.g:",
+            '    SlurmExecutor(..., variables={"COVALENT_CONFIG_DIR": "/tmp"})'
+            ''
+        ])
+        exception = _exception
+
+    # Raise the exception if one was caught
+    if exception:
+        raise RuntimeError(msg) from exception
+
+
+def _execute() -> dict:
+    """Load and execute the @electron function"""
+
+    func_filename = sys.argv[1]
+
+    with open(func_filename, "rb") as f:
+        function, args, kwargs = pickle.load(f)
+
+    result = None
+    exception = None
+
+    try:
+        result = function(*args, **kwargs)
+    except Exception as ex:
+        exception = ex
+
+    return {
+        "result": result,
+        "exception": exception,
+    }
+
+
+def main():
+    """Execute the @electron function on the Slurm cluster."""
+
+    output_data = {
+        "result": None,
+        "exception": None,
+        "result_filename": sys.argv[2],
+    }
+    try:
+        _check_setup()
+        output_data.update(**_execute())
+
+    except Exception as ex:
+        output_data.update(exception=ex)
+
+    finally:
+        _record_output(**output_data)
+
+
+def _record_output(result, exception, result_filename) -> None:
+    """Record the output of the @electron function"""
+
+    with open(result_filename, "wb") as f:
+        pickle.dump((result, exception), f)
+
+
+if __name__ == "__main__":
+    main()

--- a/covalent_slurm_plugin/job_script.py
+++ b/covalent_slurm_plugin/job_script.py
@@ -1,0 +1,234 @@
+# Copyright 2021 Agnostiq Inc.
+#
+# This file is part of Covalent.
+#
+# Licensed under the Apache License 2.0 (the "License"). A copy of the
+# License may be obtained with this software package or at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Use of this file is prohibited except in compliance with the License.
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import re
+from typing import Dict, List, Optional
+
+
+SLURM_JOB_SCRIPT_TEMPLATE = """\
+#!/bin/bash
+{sbatch_directives}
+
+{shell_env_setup}
+
+{conda_env_setup}
+
+retval=$?
+if [ $retval -ne 0 ] ; then
+  >&2 echo "Failed to activate conda env '$_conda_env_name' on compute node."
+  exit 99
+fi
+
+remote_py_version=$(python -c "print('.'.join(map(str, __import__('sys').version_info[:2])))")
+if [[ "{python_version}" != $remote_py_version ]] ; then
+  >&2 echo "Python version mismatch. Please install Python {python_version} in the compute environment."
+  exit 199
+fi
+
+covalent_version=$(python -c "import covalent; print(covalent.__version__, end='')")
+if [[ $covalent_version != "{covalent_version}" ]] ; then
+  >&2 echo "Covalent version mismatch."
+  >&2 echo "Compute environment has 'covalent==$covalent_version', user has 'covalent=={covalent_version}'"
+  exit 299
+fi
+
+cloudpickle_version=$(python -c "import cloudpickle; print(cloudpickle.__version__)")
+if [[ $cloudpickle_version != "{cloudpickle_version}" ]] ; then
+  >&2 echo "Cloudpickle version mismatch."
+  >&2 echo "Compute environment has 'cloudpickle==$cloudpickle_version', but user has 'cloudpickle=={cloudpickle_version}'"
+  exit 399
+fi
+
+{run_commands}
+
+wait
+"""
+
+
+class JobScript:
+    """Create a job script for the Slurm cluster."""
+
+    def __init__(
+        self,
+        sbatch_options: Optional[Dict[str, str]] = None,
+        srun_options: Optional[Dict[str, str]] = None,
+        variables: Optional[Dict[str, str]] = None,
+        bashrc_path: Optional[str] = None,
+        conda_env: Optional[str] = None,
+        prerun_commands: Optional[List[str]] = None,
+        srun_append: Optional[str] = None,
+        postrun_commands: Optional[List[str]] = None,
+        use_srun: bool = True,
+    ):
+        # TODO: docstring
+
+        self._sbatch_options = sbatch_options or {}
+        self._srun_options = srun_options or {}
+        self._variables = variables or {}
+        self._bashrc_path = bashrc_path
+        self._conda_env = conda_env
+        self._prerun_commands = prerun_commands or []
+        self._srun_append = srun_append
+        self._postrun_commands = postrun_commands or []
+        self._use_srun = use_srun
+
+    @property
+    def sbatch_directives(self) -> str:
+        """Get the sbatch directives."""
+        directives = []
+        for key, value in self._sbatch_options.items():
+            if len(key) == 1:
+                directives.append(f"#SBATCH -{key}" + (f" {value}" if value else ""))
+            else:
+                directives.append(f"#SBATCH --{key}" + (f"={value}" if value else ""))
+
+        return "\n".join(directives)
+
+    @property
+    def shell_env_setup(self) -> str:
+        """Get the shell environment setup."""
+        setup_lines = [
+            f"source {self._bashrc_path}" if self._bashrc_path else "",
+        ]
+        for key, value in self._variables.items():
+            setup_lines.append(f'export {key}="{value}"')
+
+        return "\n".join(setup_lines)
+
+    @property
+    def conda_env_setup(self) -> str:
+        """Get the conda environment setup."""
+        setup_lines = []
+        if not self._conda_env or self._conda_env == "base":
+            conda_env_name = "base"
+            setup_lines.append("conda activate")
+        else:
+            conda_env_name = self._conda_env
+            setup_lines.append(f"conda activate {self._conda_env}")
+
+        setup_lines.append(f'_conda_env_name="{conda_env_name}"')
+
+        return "\n".join(setup_lines)
+
+    @property
+    def covalent_version(self) -> str:
+        """Get the version of Covalent installed in the compute environment."""
+        import covalent
+
+        return covalent.__version__
+
+    @property
+    def cloudpickle_version(self) -> str:
+        """Get the version of cloudpickle installed in the compute environment."""
+        import cloudpickle
+
+        return cloudpickle.__version__
+
+    @property
+    def prerun_commands(self) -> str:
+        """Get the prerun commands."""
+
+        return "\n".join(self._prerun_commands)
+
+    def get_run_commands(
+        self,
+        remote_py_filename: str,
+        func_filename: str,
+        result_filename: str,
+    ) -> str:
+        """Get the run commands."""
+
+        # Commands executed before the user's @electron function.
+        if not self._prerun_commands:
+            prerun_cmds = ""
+        else:
+            prerun_cmds = "\n".join(self._prerun_commands)
+
+        # Command that executes the user's @electron function.
+        if self._use_srun:
+            srun_options = []
+            for key, value in self._srun_options.items():
+                if len(key) == 1:
+                    srun_options.append(f"-{key}" + (f" {value}" if value else ""))
+                else:
+                    srun_options.append(f"--{key}" + (f"={value}" if value else ""))
+
+            run_cmds = [
+                f"srun {' '.join(srun_options)} \\" if srun_options else "srun \\",
+                "  python {remote_py_filename} {func_filename} {result_filename}",
+            ]
+            if self._srun_append:
+                run_cmds.insert(1, f"  {self._srun_append} \\")
+
+            run_cmd = "\n".join(run_cmds)
+        else:
+            run_cmd = "python {remote_py_filename} {func_filename} {result_filename}"
+
+        run_cmd = run_cmd.format(
+            remote_py_filename=remote_py_filename,
+            func_filename=func_filename,
+            result_filename=result_filename,
+        )
+
+        # Commands executed after the user's @electron function.
+        if not self._postrun_commands:
+            postrun_cmds = ""
+        else:
+            postrun_cmds = "\n".join(self._postrun_commands)
+
+        run_commands = [prerun_cmds, run_cmd, postrun_cmds]
+        run_commands = [cmd for cmd in run_commands if cmd]
+
+        return "\n\n".join(run_commands)
+
+    @property
+    def postrun_commands(self) -> str:
+        """Get the postrun commands."""
+
+        return "\n".join(self._postrun_commands)
+
+    def format(
+        self,
+        python_version: str,
+        remote_py_filename: str,
+        func_filename: str,
+        result_filename: str,
+    ) -> str:
+        """Render the job script."""
+        template_kwargs = {
+            "sbatch_directives": self.sbatch_directives,
+            "shell_env_setup": self.shell_env_setup,
+            "conda_env_setup": self.conda_env_setup,
+            "covalent_version": self.covalent_version,
+            "cloudpickle_version": self.cloudpickle_version,
+            "python_version": python_version,
+            "run_commands": self.get_run_commands(
+                remote_py_filename=remote_py_filename,
+                func_filename=func_filename,
+                result_filename=result_filename,
+            ),
+        }
+        existing_keys = set(template_kwargs.keys())
+        required_keys = set(re.findall(r"\{(\w+)\}", SLURM_JOB_SCRIPT_TEMPLATE))
+
+        if (missing_keys := required_keys - existing_keys):
+            raise ValueError(f"Missing required keys: {', '.join(missing_keys)}")
+
+        if (extra_keys := existing_keys - required_keys):
+            raise ValueError(f"Unexpected keys: {', '.join(extra_keys)}")
+
+        return SLURM_JOB_SCRIPT_TEMPLATE.format(**template_kwargs)

--- a/covalent_slurm_plugin/job_script.py
+++ b/covalent_slurm_plugin/job_script.py
@@ -55,7 +55,7 @@ if [ $? -ne 0 ] ; then
   >&2 echo "Cloudpickle may not be installed in the compute environment."
   >&2 echo "Please install cloudpickle=={cloudpickle_version} in the '$__env_name' environment."
   exit 399
-if [[ $cloudpickle_version != "{cloudpickle_version}" ]] ; then
+elif [[ $cloudpickle_version != "{cloudpickle_version}" ]] ; then
   >&2 echo "Cloudpickle version mismatch."
   >&2 echo "Environment '$__env_name' (cloudpickle==$cloudpickle_version) does not match task (cloudpickle=={cloudpickle_version})."
   exit 399

--- a/covalent_slurm_plugin/slurm.py
+++ b/covalent_slurm_plugin/slurm.py
@@ -475,10 +475,10 @@ class SlurmExecutor(AsyncBaseExecutor):
         conn = await self._client_connect()
 
         py_version_func = ".".join(function.args[0].python_version.split(".")[:2])
-        app_log.debug(f"Python version: {py_version_func}")
+        app_log.debug("Python version: %s", py_version_func)
 
         # Create the remote directory
-        app_log.debug(f"Creating remote work directory {current_remote_workdir} ...")
+        app_log.debug("Creating remote work directory %s ...", current_remote_workdir)
         cmd_mkdir_remote = f"mkdir -p {current_remote_workdir}"
         proc_mkdir_remote = await conn.run(cmd_mkdir_remote)
 
@@ -492,7 +492,7 @@ class SlurmExecutor(AsyncBaseExecutor):
             await temp_f.flush()
 
             remote_func_filename = os.path.join(self.remote_workdir, func_filename)
-            app_log.debug(f"Copying pickled function to remote fs: {remote_func_filename} ...")
+            app_log.debug("Copying pickled function to remote fs: %s ...", remote_func_filename)
             await asyncssh.scp(temp_f.name, (conn, remote_func_filename))
 
         async with aiofiles.tempfile.NamedTemporaryFile(dir=self.cache_dir, mode="w") as temp_g:
@@ -503,7 +503,7 @@ class SlurmExecutor(AsyncBaseExecutor):
             await temp_g.flush()
 
             remote_py_script_filename = os.path.join(self.remote_workdir, py_script_filename)
-            app_log.debug(f"Copying python run-function to remote fs: {remote_py_script_filename}")
+            app_log.debug("Copying python run-function to remote fs: %s", remote_py_script_filename)
             await asyncssh.scp(temp_g.name, (conn, remote_py_script_filename))
 
         async with aiofiles.tempfile.NamedTemporaryFile(dir=self.cache_dir, mode="w") as temp_h:
@@ -520,11 +520,11 @@ class SlurmExecutor(AsyncBaseExecutor):
             await temp_h.flush()
 
             remote_slurm_filename = os.path.join(current_remote_workdir, slurm_filename)
-            app_log.debug(f"Copying slurm submit script to remote fs: {remote_slurm_filename} ...")
+            app_log.debug("Copying slurm submit script to remote fs: %s", remote_slurm_filename)
             await asyncssh.scp(temp_h.name, (conn, remote_slurm_filename))
 
         # Execute the script
-        app_log.debug(f"Running the script: {remote_slurm_filename} ...")
+        app_log.debug("Running the script: %s", remote_slurm_filename)
         cmd_sbatch = f"sbatch {remote_slurm_filename}"
         if self.slurm_path:
             app_log.debug("Exporting slurm path for sbatch...")
@@ -541,13 +541,13 @@ class SlurmExecutor(AsyncBaseExecutor):
         if proc.returncode != 0:
             raise RuntimeError(proc.stderr.strip())
 
-        app_log.debug(f"Job submitted with stdout: {proc.stdout.strip()}")
+        app_log.debug("Job submitted with stdout: %s", proc.stdout.strip())
         slurm_job_id = int(re.findall("[0-9]+", proc.stdout.strip())[0])
 
-        app_log.debug(f"Polling slurm with job_id: {slurm_job_id} ...")
+        app_log.debug("Polling slurm with job_id: %s ...", slurm_job_id)
         await self._poll_slurm(slurm_job_id, conn)
 
-        app_log.debug(f"Querying result with job_id: {slurm_job_id} ...")
+        app_log.debug("Querying result with job_id: %s ...", slurm_job_id)
         result, stdout, stderr, exception = await self._query_result(
             result_filename, task_results_dir, conn
         )

--- a/covalent_slurm_plugin/slurm.py
+++ b/covalent_slurm_plugin/slurm.py
@@ -245,8 +245,8 @@ class SlurmExecutor(AsyncBaseExecutor):
 
         except Exception as e:
             raise RuntimeError(
-                f"Could not connect to host: '{self.address}' as user: '{self.username}'", e
-            )
+                f"Could not connect to host: '{self.address}' as user: '{self.username}'"
+            ) from e
 
         return conn
 

--- a/covalent_slurm_plugin/slurm.py
+++ b/covalent_slurm_plugin/slurm.py
@@ -352,9 +352,17 @@ if [[ "{python_version}" != $remote_py_version ]] ; then
 fi
 
 covalent_version=$(python -c "import covalent; print(covalent.__version__, end='')")
-if [[ "{covalent_version}" != $covalent_version ]] ; then
-  >&2 echo "covalent version mismatch. Compute environment 'covalent=$covalent_version' versus user's 'covalent=={covalent_version}'."
-  exit 199
+if [[ $covalent_version != "{covalent_version}" ]] ; then
+  >&2 echo "Covalent version mismatch."
+  >&2 echo "Compute environment has 'covalent==$covalent_version', user has 'covalent=={covalent_version}'"
+  exit 299
+fi
+
+cloudpickle_version=$(python -c "import cloudpickle; print(cloudpickle.__version__)")
+if [[ $cloudpickle_version != "{pickle.__version__}" ]] ; then
+  >&2 echo "Cloudpickle version mismatch."
+  >&2 echo "Compute environment has 'cloudpickle==$cloudpickle_version', but user has 'cloudpickle=={pickle.__version__}'"
+  exit 399
 fi
 """
         # runs pre-run commands

--- a/covalent_slurm_plugin/slurm.py
+++ b/covalent_slurm_plugin/slurm.py
@@ -59,7 +59,7 @@ class ExecutorPluginDefaults(BaseModel):
     srun_append: Optional[str] = ""
     bashrc_path: Optional[str] = "$HOME/.bashrc"
     slurm_path: Optional[str] = "/usr/bin"
-    poll_freq: int = 60
+    poll_freq: int = 10
     cleanup: bool = True
     cache_dir: Optional[str] = str(
         Path.home() / ".config/covalent/executor_plugins/covalent-slurm-cache"
@@ -175,9 +175,9 @@ class SlurmExecutor(AsyncBaseExecutor):
             else cleanup
         )
         # Force minimum value on `poll_freq`.
-        if self.poll_freq < 60:
-            app_log.info("Increasing poll_freq to the minimum for Slurm: 60 seconds.")
-            self.poll_freq = 60
+        if self.poll_freq < 10:
+            app_log.info("Increasing poll_freq to the minimum allowed: 10 seconds.")
+            self.poll_freq = 10
 
         # Create cache dir if it doesn't exist.
         if not self.cache_dir.exists():


### PR DESCRIPTION
### Updated the plugin with the following changes:

- add a new `variables` parameter for environment variables
- update plugin defaults to use `BaseModel` instead of `dict`
- add a new error-catching python execution script (new module)
- add checks inside submit script for `covalent` and `cloudpickle` versions
- change to actually get errors from these checks
- clean up job script creation (new module)
- use `Path` everywhere instead of `os.path` operations
- allow `poll_freq >= 10` seconds, instead of 60 seconds
- misc. cleanups and refactoring

---

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation, VERSION, and CHANGELOG accordingly.
- [ ] I have read the CONTRIBUTING document.
